### PR TITLE
bug fix for `bam2fastq_xx.sh` script can not be created at run time.

### DIFF
--- a/helpers/wgs_pipeline.py
+++ b/helpers/wgs_pipeline.py
@@ -885,9 +885,9 @@ def bam2fastq(
         #
         # Make sure files exist.
         #
-        if not os.path.isfile( input_file ):
+        if not os.path.isfile( input_file1 ):
             with log_mutex:
-                log.error( "file: {file} does not exist.".format( file=input_file ) )
+                log.error( "file: {file} does not exist.".format( file=input_file1 ) )
             raise
 
         #
@@ -897,23 +897,15 @@ def bam2fastq(
         shell_script_file = open( shell_script_full_path, 'w' )
 
         file_type = Geno.job.get_job( 'input_file_type' )
-        if 'paired_bam' == file_type:
+
+        if 'bam' == file_type:
             shell_script_file.write( wgs_res.bamtofastq_p.format(
                                             log = Geno.dir[ 'log' ],
                                             bamfile = input_file1,
                                             outfastq1 = output_file1,
                                             outfastq2 = output_file2,
                                             tmpfastq = output_file1 + '.tmp',
-                                            bamtofastq = Geno.conf.get( 'SOFTWARE', 'bamtofastq' ),
-                                            scriptdir = Geno.dir[ 'script' ]
-                                            ) )
-        elif 'single_bam' == file_type:
-            shell_script_file.write( wgs_res.bamtofastq_s.format(
-                                            log = Geno.dir[ 'log' ],
-                                            bamfile = input_file1,
-                                            outfastq1 = output_file1,
-                                            tmpfastq = output_file1 + '.tmp',
-                                            bamtofastq = Geno.conf.get( 'SOFTWARE', 'bamtofastq' ),
+                                            biobambam = Geno.conf.get( 'SOFTWARE', 'biobambam' ),
                                             scriptdir = Geno.dir[ 'script' ]
                                             ) )
         shell_script_file.close()
@@ -2203,8 +2195,8 @@ Sample = Sample()
 @active_if( 'bam2fastq' in Geno.job.get_job( 'tasks' )[ 'WGS' ] )
 @parallel( generate_params_for_bam2fastq )
 @check_if_uptodate( check_file_exists_for_bam2fastq )
-def stage_1( input_file, output_file ):
-    return_value =  bam2fastq( input_file, output_file )
+def stage_1( input_file1, input_file2, output_file1, output_file2 ):
+    return_value =  bam2fastq( input_file1, input_file2, output_file1, output_file2 )
     if not return_value:
         raise
 

--- a/resource/genomon_rc.py
+++ b/resource/genomon_rc.py
@@ -83,7 +83,8 @@ subdir_list = ( 'fastq',
                 'summary',
                 'all_summary' )
 
-dir_task_list = { 'fastq':          'split_fastq',
+dir_task_list = { 'bam2fastq':     'bam2fastq',
+                  'fastq':          'split_fastq',
                   'bam':            'bwa_mem',
                   'bam':            'merge_bam',
                   'bam':            'markduplicates',

--- a/resource/wgs_resource.py
+++ b/resource/wgs_resource.py
@@ -18,7 +18,7 @@ date                    # print date
 set -xv
 
 source {scriptdir}/utility.sh
-{bamtofastq}  exclude=QCFAIL,SECONDARY,SUPPLEMENTARY\
+{biobambam}/bamtofastq  exclude=QCFAIL,SECONDARY,SUPPLEMENTARY\
             T={tmpfastq}\
             F={outfastq1}\
             collate=1\
@@ -43,7 +43,7 @@ set -xv
 
 source {scriptdir}/utility.sh
 
-{bamtofastq}  exclude=QCFAIL,SECONDARY,SUPPLEMENTARY\
+{biobambam}/bamtofastq  exclude=QCFAIL,SECONDARY,SUPPLEMENTARY\
             T={tmpfastq}\
             F={outfastq1}\
             F2={outfastq2}\

--- a/samples/sample3_job.yaml
+++ b/samples/sample3_job.yaml
@@ -82,7 +82,7 @@ tasks:
                         - merge_bam
 # tasks type
 #                    WGS:
-#                        - bamtofastq
+#                        - bam2fastq
 #                        - split_fastq
 #                        - cutadapt
 #                        - bwa_mem


### PR DESCRIPTION
bamtofastq実行時に `bam2fastq_xx.sh` スクリプトが作成されず、エラーになる不具合に対応しました。
また、job.yaml で指定するbamファイルは `paired_bam` のみに変更しました。